### PR TITLE
Adds `Copy GitHub URL` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
 ## Version 1.0
 
 Initial release
+
+## Version 1.0.1
+
+Added `Copy GitHub Reference to Clipboard` command

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,6 @@
 
 Initial release
 
-## Version 1.0.1
+## Version 1.1.0
 
-Added `Copy GitHub Reference to Clipboard` command
+Added `Copy GitHub URL` command

--- a/README.md
+++ b/README.md
@@ -31,5 +31,8 @@ which is what other GitHub extensions seem to choose.
 
 ## Usage
 
-Defines the command "Open on GitHub" command, which opens the current file (and selected line range) on GitHub.
-No default key-bindings, but I use cmd-option-G.
+Defines the following commands:
+
+- "Open on GitHub" - which opens the current file (and selected line range) on GitHub. No default key-bindings, but I use cmd-option-G.
+- "Copy GitHub reference to Clipboard" - copies the reference URL to the clipboard
+

--- a/README.md
+++ b/README.md
@@ -34,4 +34,4 @@ which is what other GitHub extensions seem to choose.
 Defines the following commands:
 
 - "Open on GitHub" - which opens the current file (and selected line range) on GitHub. No default key-bindings, but I use cmd-option-G.
-- "Copy GitHub URL to Clipboard" - copies the reference URL to the clipboard
+- "Copy GitHub URL" - copies the URL to the current file (and selected line range) to the clipboard

--- a/README.md
+++ b/README.md
@@ -35,4 +35,3 @@ Defines the following commands:
 
 - "Open on GitHub" - which opens the current file (and selected line range) on GitHub. No default key-bindings, but I use cmd-option-G.
 - "Copy GitHub reference to Clipboard" - copies the reference URL to the clipboard
-

--- a/README.md
+++ b/README.md
@@ -34,5 +34,5 @@ which is what other GitHub extensions seem to choose.
 Defines the following commands:
 
 - "Open on GitHub" - which opens the current file (and selected line range) on GitHub. No default key-bindings, but I use cmd-option-G.
-- "Copy GitHub reference to Clipboard" - copies the reference URL to the clipboard
+- "Copy GitHub URL to Clipboard" - copies the reference URL to the clipboard
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,4 @@ which is what other GitHub extensions seem to choose.
 Defines the following commands:
 
 - "Open on GitHub" - which opens the current file (and selected line range) on GitHub. No default key-bindings, but I use cmd-option-G.
-<<<<<<< HEAD
 - "Copy GitHub URL to Clipboard" - copies the reference URL to the clipboard
-
-=======
-- "Copy GitHub reference to Clipboard" - copies the reference URL to the clipboard
->>>>>>> adds-copy-reference

--- a/Scripts/main.js
+++ b/Scripts/main.js
@@ -11,7 +11,7 @@ nova.commands.register("github-tools.openFile", async (workspace) => {
   nova.openURL(url);
 });
 
-nova.commands.register("github-tools.copyReference", async (workspace) => {
+nova.commands.register("github-tools.copyUrl", async (workspace) => {
   var url = await getUrl(workspace);
   nova.clipboard.writeText(url);
 });

--- a/Scripts/main.js
+++ b/Scripts/main.js
@@ -58,7 +58,7 @@ async function getRemoteUrl(repoRoot, remote) {
     url = url.slice(0, -4);
   }
   // light parsing of URLs
-  if (url.indexOf("@")) {
+  if (url.indexOf("@") >= 0) {
     // turn git@github.com:minrk/foo
     // into https://github.com/minrk/foo
     const parts = url.slice(url.indexOf("@") + 1).split(":");

--- a/Scripts/main.js
+++ b/Scripts/main.js
@@ -14,7 +14,7 @@ nova.commands.register("github-tools.openFile", async (workspace) => {
 nova.commands.register("github-tools.copyReference", async (workspace) => {
   var url = await getUrl(workspace);
   nova.clipboard.writeText(url);
-})
+});
 
 // TODO: option?
 const git = "/usr/bin/git";

--- a/Scripts/main.js
+++ b/Scripts/main.js
@@ -11,6 +11,11 @@ nova.commands.register("github-tools.openFile", async (workspace) => {
   nova.openURL(url);
 });
 
+nova.commands.register("github-tools.copyReference", async (workspace) => {
+  var url = await getUrl(workspace);
+  nova.clipboard.writeText(url);
+})
+
 // TODO: option?
 const git = "/usr/bin/git";
 

--- a/extension.json
+++ b/extension.json
@@ -3,7 +3,7 @@
   "name": "GitHub tools",
   "organization": "minrk",
   "description": "Tools for working with GitHub (open on GitHub)",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "categories": ["commands"],
   "license": "MIT",
   "homepage": "https://github.com/minrk/github-tools.novaextension",
@@ -25,7 +25,7 @@
         "command": "github-tools.openFile"
       },
       {
-        "title": "Copy GitHub URL to Clipboard",
+        "title": "Copy GitHub URL",
         "command": "github-tools.copyUrl"
       }
     ]

--- a/extension.json
+++ b/extension.json
@@ -25,8 +25,8 @@
         "command": "github-tools.openFile"
       },
       {
-        "title": "Copy GitHub Reference to Clipboard",
-        "command": "github-tools.copyReference"
+        "title": "Copy GitHub URL to Clipboard",
+        "command": "github-tools.copyUrl"
       }
     ]
   },

--- a/extension.json
+++ b/extension.json
@@ -3,7 +3,7 @@
   "name": "GitHub tools",
   "organization": "minrk",
   "description": "Tools for working with GitHub (open on GitHub)",
-  "version": "1.0",
+  "version": "1.0.1",
   "categories": ["commands"],
   "license": "MIT",
   "homepage": "https://github.com/minrk/github-tools.novaextension",
@@ -14,6 +14,7 @@
   "activationEvents": [],
 
   "entitlements": {
+    "clipboard": true,
     "process": true
   },
 
@@ -22,6 +23,10 @@
       {
         "title": "Open on GitHub",
         "command": "github-tools.openFile"
+      },
+      {
+        "title": "Copy GitHub Reference to Clipboard",
+        "command": "github-tools.copyReference"
       }
     ]
   },


### PR DESCRIPTION
Adds one method to copy the generated URL directly to the clipboard.

I also ran into some issues with https://github.com/minrk/github-tools.novaextension/blob/HEAD/Scripts/main.js#L63 where it was rebuilding the url even though the `@` wasn't present, so I just added a safety check.

